### PR TITLE
Remove "also" in "Users who have also scrobbled.."

### DIFF
--- a/NewFrontend/app/src/app/components/artist/artist.component.html
+++ b/NewFrontend/app/src/app/components/artist/artist.component.html
@@ -1,6 +1,6 @@
 <div class="tableComponent">
   <div class="tableComponent__header">
-    Users who have also scrobbled {{artist}}
+    Users who have scrobbled {{artist}}
   </div>
   <table class="tableComponent__table tableComponent__table--striped">
     <thead>


### PR DESCRIPTION
Since the user is shown in the list, "Users who have _also_ scrobbled" doesn't really make much sense.

Pull request changes it to "Users who have scrobbled {{artist}}".
